### PR TITLE
improvement/#18458/Fix executable permission on multiple cookbook

### DIFF
--- a/packaging/rpm/cookbook-rb-events-counter.spec
+++ b/packaging/rpm/cookbook-rb-events-counter.spec
@@ -48,7 +48,8 @@ if [ "$1" = 0 ] && [ -d /var/chef/cookbooks/rb-events-counter ]; then
 fi
 
 %files
-%defattr(0755,root,root)
+%defattr(0644,root,root)
+%attr(0755,root,root)
 %{cookbook_path}
 %defattr(0644,root,root)
 %{cookbook_path}/README.md


### PR DESCRIPTION
## Related issue in RedMine

Fix incorrect file permissions in packaged cookbook
[https://redmine.redborder.lan/issues/18458]

## Description / Motivation

The cookbook RPM installs with incorrect file permissions: all files inside /var/chef/cookbooks/druid are marked as executable (0755), including .rb, .erb and other files that do not require execution permissions.

This PR fixes the packaging spec to prevent unnecessary +x on non-executable files.

## Detail

The issue stems from the use of %defattr(0755,root,root) under the %files section in the RPM spec file. This directive recursively applies 0755 permissions to all files listed, causing .rb, .erb, and other files to be installed with executable permission.

To fix this,

```sh
%defattr(0755,root,root)
/var/chef/cookbooks/"name"
```

has been changed to:

```sh
%defattr(0644,root,root)
%attr(0755,root,root)
/var/chef/cookbooks/"name"
```

This ensures that:

All files receive default 0644 permissions (readable, writable by root, not executable).

The cookbook directory /var/chef/cookbooks/"name" is still executable so Chef can access its contents properly.

This avoids granting execution rights to source files unnecessarily.

## Additional information

This issue does not affect Chef’s ability to run recipes, since execution of the files is handled by the Chef interpreter, not directly by the shell.